### PR TITLE
Attempt to handle BOM characters in CSV parsing

### DIFF
--- a/examples/csv_to_ndjson/README.md
+++ b/examples/csv_to_ndjson/README.md
@@ -96,6 +96,17 @@ vim -b test_file.csv
 1232,99^M
 ```
 
+You can also use `cat` with the `-vet` option to show non-printing, newline and tab
+characters, e.g.
+```
+cat -vet test_file.csv | head
+M-oM-;M-?link.customer_id,custom_fields.loyalty_points^M$
+1234,16^M$
+5678,188^M$
+91011,0^M$
+1232,99^M$
+```
+
 If the headers detected by the script don't match what you expect or you can see
 special characters in the file you should try manually removing these characters
 and making sure the file is saved as UTF-8 before retrying the script.

--- a/examples/csv_to_ndjson/README.md
+++ b/examples/csv_to_ndjson/README.md
@@ -73,7 +73,7 @@ to upload it to a dataset on Lexer
 ## Troubleshooting
 
 A common pitfall with dealing with CSV files is that they can contain invisible
-control characters that intefere with the parsing of the rows and columns, or the
+control characters that interfere with the parsing of the rows and columns, or the
 file itself might be using an unexpected encoding.
 
 This example script contains some logic to detect the encoding of the file and 
@@ -82,9 +82,9 @@ that it fails to parse.
 
 You can use the `--debug-csv` flag to print out what encoding the script has detected
 and also what headers it has found, which can be useful to identify if you 
-encountering an issue realted to invisible characters or file encoding.
+encountering an issue related to invisible characters or file encoding.
 
-Tools like `vim` can also be used to identify specicial characters,
+Tools like `vim` can also be used to identify special characters,
 e.g. open your CSV file using the `-b` flag:
 ```
 vim -b test_file.csv 

--- a/examples/csv_to_ndjson/README.md
+++ b/examples/csv_to_ndjson/README.md
@@ -50,11 +50,12 @@ to install the dependencies.
 
 ## Running
 
-The script has 3 command line arguments
+The script has 4 command line arguments
 
 - `--input-file` - A CSV file to read
 - `--record-type` - A lexer schema record type api name, eg `customer_record`
 - `--output-file` - A path to write the output ndjson file to.
+- `--debug-csv` - Optional, prints details about the file encoding and headers that were detected.
 
 eg:
 
@@ -69,4 +70,32 @@ Once you have a ndjson file, you can use the script in `examples/file_upload_api
 to upload it to a dataset on Lexer
 
 
+## Troubleshooting
 
+A common pitfall with dealing with CSV files is that they can contain invisible
+control characters that intefere with the parsing of the rows and columns, or the
+file itself might be using an unexpected encoding.
+
+This example script contains some logic to detect the encoding of the file and 
+automatically clean up various "BOM" characters, however you might still encounter files
+that it fails to parse.
+
+You can use the `--debug-csv` flag to print out what encoding the script has detected
+and also what headers it has found, which can be useful to identify if you 
+encountering an issue realted to invisible characters or file encoding.
+
+Tools like `vim` can also be used to identify specicial characters,
+e.g. open your CSV file using the `-b` flag:
+```
+vim -b test_file.csv 
+
+<feff>link.customer_id,custom_fields.loyalty_points^M
+1234,16^M
+5678,188^M
+91011,0^M
+1232,99^M
+```
+
+If the headers detected by the script don't match what you expect or you can see
+special characters in the file you should try manually removing these characters
+and making sure the file is saved as UTF-8 before retrying the script.


### PR DESCRIPTION
A common pitfall with dealing with CSV files is that they can contain invisible control characters that interfere with the parsing of the rows and columns, or the file itself might be using an unexpected encoding.

This change adds detection of file encoding and cleaning of BOM characters to attempt to make it more robust when parsing CSV files.

Task: https://app.asana.com/0/1201314691604883/1205504797831269/f